### PR TITLE
Make use of kotlin eap 1.3.60 with fix KT-33710

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("js") version "1.3.50"
+  kotlin("js") version "1.3.60-eap-23"
 }
 
 kotlin {
@@ -16,7 +16,7 @@ kotlin {
 }
 
 repositories {
-  mavenLocal()
+    mavenLocal()
 }
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,6 @@
-
+pluginManagement {
+    repositories {
+        maven(url = "https://dl.bintray.com/kotlin/kotlin-eap")
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
When using the eap version the issue #3 is fixed.
Also see: 
* https://github.com/Kotlin/dukat/issues/105
* https://youtrack.jetbrains.com/issue/KT-33710